### PR TITLE
Refactor mapfileparser

### DIFF
--- a/QMapfileEditor.pro
+++ b/QMapfileEditor.pro
@@ -21,6 +21,7 @@ SOURCES += \
         commands/changemapstatuscommand.cpp    \
         commands/outputformatcommands.cpp      \
         commands/setanglecommand.cpp           \
+        commands/setconfigoptioncommand.cpp    \
         commands/setdatapatterncommand.cpp     \
         commands/setdefresolutioncommand.cpp   \
         commands/setfontsetcommand.cpp         \
@@ -51,6 +52,7 @@ HEADERS  += \
     commands/changemapstatuscommand.h       \
     commands/outputformatcommands.h         \
     commands/setanglecommand.h              \
+    commands/setconfigoptioncommand.h       \
     commands/setdatapatterncommand.h        \
     commands/setdefresolutioncommand.h      \
     commands/setfontsetcommand.h            \

--- a/commands/outputformatcommands.cpp
+++ b/commands/outputformatcommands.cpp
@@ -79,9 +79,7 @@ void UpdateOutputFormatCommand::redo(void) {
   parser->updateOutputFormat(fmtToUpdate);
 }
 
-UpdateOutputFormatCommand::~UpdateOutputFormatCommand() {
-  delete originalFmt;
-}
+UpdateOutputFormatCommand::~UpdateOutputFormatCommand() {}
 
 
 /**  related to setting the default outputformat */

--- a/commands/outputformatcommands.cpp
+++ b/commands/outputformatcommands.cpp
@@ -73,7 +73,7 @@ RemoveOutputFormatCommand::~RemoveOutputFormatCommand() {
 /** related to modifying an existing Output Format */
 
 UpdateOutputFormatCommand::UpdateOutputFormatCommand(OutputFormat *fmtToUpdate, MapfileParser *parser, QUndoCommand *parent)
-     : QUndoCommand(parent), fmtToUpdate(fmtToUpdate), parser(parser)
+     : QUndoCommand(parent), fmtToUpdate(new OutputFormat(* fmtToUpdate)), parser(parser)
 {
   originalFmt = parser->getOutputFormat(fmtToUpdate->getOriginalName());
   setText(QObject::tr("Update outputformat '%1'").arg(fmtToUpdate->getName()));
@@ -88,7 +88,11 @@ void UpdateOutputFormatCommand::redo(void) {
   parser->updateOutputFormat(fmtToUpdate);
 }
 
-UpdateOutputFormatCommand::~UpdateOutputFormatCommand() {}
+UpdateOutputFormatCommand::~UpdateOutputFormatCommand() {
+  // both objects are managed by the QUndo command
+  delete fmtToUpdate;
+  delete originalFmt;
+}
 
 
 /**  related to setting the default outputformat */

--- a/commands/outputformatcommands.cpp
+++ b/commands/outputformatcommands.cpp
@@ -31,8 +31,9 @@
 /** related to adding a new Output Format */
 
 AddNewOutputFormatCommand::AddNewOutputFormatCommand(OutputFormat *newFormat, MapfileParser *parser, QUndoCommand *parent)
-     : QUndoCommand(parent), newFormat(newFormat), parser(parser)
+     : QUndoCommand(parent), parser(parser)
 {
+  this->newFormat = new OutputFormat(* newFormat);
   setText(QObject::tr("Create new outputformat '%1'").arg(newFormat->getName()));
 }
 
@@ -44,21 +45,29 @@ void AddNewOutputFormatCommand::redo(void) {
   parser->addOutputFormat(newFormat);
 }
 
+AddNewOutputFormatCommand::~AddNewOutputFormatCommand() {
+  delete newFormat;
+}
+
 /** related to removing an Output Format */
 
 RemoveOutputFormatCommand::RemoveOutputFormatCommand(OutputFormat *fmtToRemove, MapfileParser *parser, QUndoCommand *parent)
-     : QUndoCommand(parent), fmtToRemove(fmtToRemove), parser(parser)
+     : QUndoCommand(parent), parser(parser)
 {
+  this->fmtToRemove = new OutputFormat(* fmtToRemove);
   setText(QObject::tr("Remove outputformat '%1'").arg(fmtToRemove->getName()));
 }
 
 void RemoveOutputFormatCommand::undo(void) {
-  // Note: What if a command adds a fmt which has the same name ?
   parser->addOutputFormat(fmtToRemove);
 }
 
 void RemoveOutputFormatCommand::redo(void) {
   parser->removeOutputFormat(fmtToRemove);
+}
+
+RemoveOutputFormatCommand::~RemoveOutputFormatCommand() {
+  delete fmtToRemove;
 }
 
 /** related to modifying an existing Output Format */

--- a/commands/outputformatcommands.h
+++ b/commands/outputformatcommands.h
@@ -37,6 +37,7 @@ class AddNewOutputFormatCommand : public QUndoCommand {
 
  public:
    AddNewOutputFormatCommand(OutputFormat * newOf, MapfileParser * parser, QUndoCommand *parent = 0);
+   ~AddNewOutputFormatCommand();
    void undo();
    void redo();
 
@@ -49,6 +50,7 @@ class RemoveOutputFormatCommand : public QUndoCommand {
 
  public:
    RemoveOutputFormatCommand(OutputFormat * fmtToRemove, MapfileParser * parser, QUndoCommand *parent = 0);
+   ~RemoveOutputFormatCommand();
    void undo();
    void redo();
 

--- a/commands/setconfigoptioncommand.cpp
+++ b/commands/setconfigoptioncommand.cpp
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * $Id$
+ *
+ * Project: QMapfileEditor
+ * Purpose: 
+ * Author: Pierre Mauduit
+ *
+ **********************************************************************
+ * Copyright (c) 2014, Pierre Mauduit
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies of this Software or works derived from this Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ ****************************************************************************/
+
+#include "setconfigoptioncommand.h"
+
+SetConfigOptionCommand::SetConfigOptionCommand(QString key, QString value, MapfileParser *parser, QUndoCommand *parent)
+     : QUndoCommand(parent), key(key), newValue(value), parser(parser)
+{
+   oldValue = parser->getMetadata(key);
+
+   setText(QObject::tr("change config option[%1] to '%2'").arg(this->key).arg(this->newValue));
+}
+
+void SetConfigOptionCommand::undo(void) {
+  parser->setConfigOption(this->key, this->oldValue);
+}
+
+void SetConfigOptionCommand::redo(void) {
+  parser->setConfigOption(this->key, this->newValue);
+}
+

--- a/commands/setconfigoptioncommand.h
+++ b/commands/setconfigoptioncommand.h
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * $Id$
+ *
+ * Project: QMapfileEditor
+ * Purpose: 
+ * Author: Pierre Mauduit
+ *
+ **********************************************************************
+ * Copyright (c) 2014, Pierre Mauduit
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies of this Software or works derived from this Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ ****************************************************************************/
+
+#ifndef SETCONFIGOPTIONCOMMAND_H
+#define SETCONFIGOPTIONCOMMAND_H
+
+#include <QUndoCommand>
+
+#include "../parser/mapfileparser.h"
+
+class SetConfigOptionCommand : public QUndoCommand {
+
+ public:
+   SetConfigOptionCommand(QString key, QString newValue, MapfileParser * parser, QUndoCommand *parent = 0);
+   void undo();
+   void redo();
+
+ private:
+   QString key;
+   QString oldValue;
+   QString newValue;
+   MapfileParser * parser;
+};
+
+
+#endif // SETCONFIGOPTIONCOMMAND_H

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -52,7 +52,7 @@ MainWindow::MainWindow(QWidget *parent) :
   ui->mf_structure->setEditTriggers(QAbstractItemView::NoEditTriggers);
   this->connect(ui->mf_structure, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(showLayerSettings(const QModelIndex &)));
   this->connect(ui->mf_editLayer, SIGNAL(clicked()), this, SLOT(showLayerSettings()));
-  
+
   // inits the graphics scene
   MapScene * mapScene = new MapScene(this);
   ui->mf_preview->setScene(mapScene);
@@ -73,9 +73,24 @@ MainWindow::MainWindow(QWidget *parent) :
   this->connect(ui->actionAbout,      SIGNAL(triggered()), SLOT(showAbout()));
   this->connect(ui->actionRefresh,    SIGNAL(triggered()), SLOT(updateMapPreview()));
 
+  // edit menu
+  this->connect(ui->actionUndo, SIGNAL(triggered()), undoStack, SLOT(undo()));
+  this->connect(ui->actionRedo, SIGNAL(triggered()), undoStack, SLOT(redo()));
+  this->connect(undoStack, SIGNAL(indexChanged(int)), this, SLOT(handleUndoStackChanged(int)));
+
   //creates a default empty mapfileparser
   this->mapfile = new MapfileParser(QString());
   this->showInfo(tr("Initialisation process: success !"));
+}
+
+
+
+// Undo / Redo related methods
+
+void MainWindow::handleUndoStackChanged(int i) {
+  Q_UNUSED(i);
+  ui->actionUndo->setText(undoStack->undoText());
+  ui->actionRedo->setText(undoStack->redoText());
 }
 
 void MainWindow::pushUndoStack(QUndoCommand *c) {
@@ -94,6 +109,7 @@ void MainWindow::showUndoStack() {
   undoView->show();
 }
 
+// Zoom / Pan / ... map related methods
 
 void MainWindow::zoomOutMapPreview() {
   double curmaxx = this->currentMapMaxX,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -89,8 +89,8 @@ MainWindow::MainWindow(QWidget *parent) :
 
 void MainWindow::handleUndoStackChanged(int i) {
   Q_UNUSED(i);
-  ui->actionUndo->setText(undoStack->undoText());
-  ui->actionRedo->setText(undoStack->redoText());
+  ui->actionUndo->setText(tr("Undo '%1'").arg(undoStack->undoText()));
+  ui->actionRedo->setText(tr("Redo '%1'").arg(undoStack->redoText()));
 }
 
 void MainWindow::pushUndoStack(QUndoCommand *c) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -357,8 +357,9 @@ void MainWindow::showMapSettings() {
   if ((! this->mapfile) || (! this->mapfile->isLoaded())) {
     return;
   }
-  // a window has alrady been created
+  // a window has already been created
   if (this->settings) {
+    this->settings->reject();
     delete this->settings;
   }
   this->settings = new MapSettings(this, this->mapfile);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -73,6 +73,7 @@ class MainWindow : public QMainWindow
       ~MainWindow();
 
  public slots:
+      void handleUndoStackChanged(int);
       void openMapfile();
       void newMapfile();
       void panPreview(qreal,qreal);

--- a/mapsettings.cpp
+++ b/mapsettings.cpp
@@ -425,10 +425,15 @@ void MapSettings::saveMapSettings() {
     for (int i = 0; i < entries.size(); ++i) {
      if (entries[i]->getState() == OutputFormat::UNCHANGED)
        continue;
-     if ((entries[i]->getState() == OutputFormat::ADDED) || (entries[i]->getState() == OutputFormat::ADDED_SAVED))
+     if ((entries[i]->getState() == OutputFormat::ADDED) || (entries[i]->getState() == OutputFormat::ADDED_SAVED)) {
+       // before inserting, consider the OF as UNCHANGED
+       entries[i]->setState(OutputFormat::UNCHANGED);
        ((MainWindow *) parent())->pushUndoStack(new AddNewOutputFormatCommand(entries[i], this->mapfile));
-     else if (entries[i]->getState() == OutputFormat::MODIFIED)
+     }
+     else if (entries[i]->getState() == OutputFormat::MODIFIED) {
+       entries[i]->setState(OutputFormat::UNCHANGED);
        ((MainWindow *) parent())->pushUndoStack(new UpdateOutputFormatCommand(entries[i], this->mapfile));
+     }
     }
 
     /** OGC tab **/

--- a/mapsettings.cpp
+++ b/mapsettings.cpp
@@ -101,26 +101,26 @@ MapSettings::MapSettings(MainWindow * parent, MapfileParser * mf) :
     this->connect(ui->mf_map_shapepath_relative, SIGNAL(clicked()), SLOT(enableRelativePathShapepath()));
     this->connect(ui->mf_map_symbolset_relative, SIGNAL(clicked()), SLOT(enableRelativePathSymbolset()));
     this->connect(ui->mf_map_fontset_relative, SIGNAL(clicked()), SLOT(enableRelativePathFontset()));
-    
+
     ui->mf_map_shapepath->setText(this->mapfile->getShapepath());
-    
+
     ui->mf_map_shapepath_relative->setChecked(true);
     if((QFileInfo (this->mapfile->getShapepath())).isAbsolute()) {
       ui->mf_map_shapepath_relative->setChecked(false);
     }
-    
+
     ui->mf_map_symbolset->setText(this->mapfile->getSymbolSet());
     ui->mf_map_symbolset_relative->setChecked(true);
     if((QFileInfo (this->mapfile->getSymbolSet())).isAbsolute()) {
       ui->mf_map_symbolset_relative->setChecked(false);
     }
-    
+
     ui->mf_map_fontset->setText(this->mapfile->getFontSet());
     ui->mf_map_fontset_relative->setChecked(true);
     if((QFileInfo (this->mapfile->getFontSet())).isAbsolute()) {
       ui->mf_map_fontset_relative->setChecked(false);
     }
-    
+
     /** Advanced tab **/
 
     //connect angle value
@@ -135,7 +135,7 @@ MapSettings::MapSettings(MainWindow * parent, MapfileParser * mf) :
     //connect relatif path for proj lib and encryption
     this->connect(ui->mf_map_config_projlib_relative, SIGNAL(clicked()), SLOT(enableRelativePathProjlib()));
     this->connect(ui->mf_map_config_encryption_relative, SIGNAL(clicked()), SLOT(enableRelativePathEncryption()));
-    
+
     //fill in form
     ui->mf_map_resolution->setValue(this->mapfile->getResolution());
     ui->mf_map_defresolution->setValue(this->mapfile->getDefResolution());
@@ -147,16 +147,17 @@ MapSettings::MapSettings(MainWindow * parent, MapfileParser * mf) :
     ui->mf_map_angle->setValue(this->mapfile->getAngle());
     ui->mf_map_templatepattern->setText(this->mapfile->getTemplatePattern());
     ui->mf_map_datapattern->setText(this->mapfile->getDataPattern());
-    
+
     ui->mf_map_config_contexturl->setText(this->mapfile->getConfigOption("CGI_CONTEXT_URL"));
-    
+
     ui->mf_map_config_encryption->setText(this->mapfile->getConfigOption("MS_ENCRYPTION_KEY"));
     ui->mf_map_config_encryption_relative->setChecked(true);
     if((QFileInfo (this->mapfile->getConfigOption("MS_ENCRYPTION_KEY"))).isAbsolute()) {
       ui->mf_map_config_encryption_relative->setChecked(false);
     }
 
-    if (! this->mapfile->getConfigOption("MS_NONSQUARE").isEmpty()) {
+    QString msNonSquare = this->mapfile->getConfigOption("MS_NONSQUARE").toLower();
+      if (msNonSquare == "yes") {
         ui->mf_map_config_squarepixel_on->setChecked(true);
         ui->mf_map_config_squarepixel_off->setChecked(false);
     } else {
@@ -169,7 +170,7 @@ MapSettings::MapSettings(MainWindow * parent, MapfileParser * mf) :
     if((QFileInfo (this->mapfile->getConfigOption("PROJ_LIB"))).isAbsolute()) {
       ui->mf_map_config_projlib_relative->setChecked(false);
     }
-    
+
     /** Output formats tab **/
 
     this->outputFormatsMapper = new QDataWidgetMapper(this);
@@ -320,7 +321,6 @@ void MapSettings::saveMapSettings() {
     }
 
     //extent
-
     if ((ui->mf_map_extent_left->text().toFloat()      != this->mapfile->getMapExtentMinX())
         || (ui->mf_map_extent_bottom->text().toFloat() != this->mapfile->getMapExtentMinY())
         || (ui->mf_map_extent_right->text().toFloat()  != this->mapfile->getMapExtentMaxX())
@@ -341,11 +341,13 @@ void MapSettings::saveMapSettings() {
                                                            this->mapfile));
     }
 
-    if (ui->mf_map_config_errorFile->text() != this->mapfile->getMetadata("ms_errorfile")) {
-      ((MainWindow *) parent())->pushUndoStack(new SetMetadataCommand("ms_errorfile", ui->mf_map_config_errorFile->text(), this->mapfile));
+    // error file (map options)
+    if (ui->mf_map_config_errorFile->text() != this->mapfile->getConfigOption("MS_ERRORFILE")) {
+      ((MainWindow *) parent())->pushUndoStack(new SetConfigOptionCommand("MS_ERRORFILE", ui->mf_map_config_errorFile->text(), this->mapfile));
     }
-    if (ui->mf_map_config_missingdata->currentText() != this->mapfile->getMetadata("missingdata")) {
-      ((MainWindow *) parent())->pushUndoStack(new SetMetadataCommand("missingdata", ui->mf_map_config_missingdata->currentText(), this->mapfile));
+    // missing data (map options)
+    if (ui->mf_map_config_missingdata->currentText() != this->mapfile->getConfigOption("ON_MISSING_DATA")) {
+      ((MainWindow *) parent())->pushUndoStack(new SetConfigOptionCommand("ON_MISSING_DATA", ui->mf_map_config_missingdata->currentText(), this->mapfile));
     }
 
     /** Path tab **/
@@ -383,29 +385,34 @@ void MapSettings::saveMapSettings() {
       ((MainWindow *) parent())->pushUndoStack(new SetDataPatternCommand(ui->mf_map_datapattern->text(), this->mapfile));
     }
 
-    if (ui->mf_map_config_contexturl->text() != this->mapfile->getMetadata("CGI_CONTEXT_URL")) {
-      ((MainWindow *) parent())->pushUndoStack(new SetMetadataCommand("CGI_CONTEXT_URL",
-                                                                      ui->mf_map_config_contexturl->text(), this->mapfile));
+    // CGI_CONTEXT_URL (map options)
+    if (ui->mf_map_config_contexturl->text() != this->mapfile->getConfigOption("CGI_CONTEXT_URL")) {
+      ((MainWindow *) parent())->pushUndoStack(new SetConfigOptionCommand("CGI_CONTEXT_URL",
+                                                                          ui->mf_map_config_contexturl->text(), this->mapfile));
     }
 
-    if (ui->mf_map_config_encryption->text() != this->mapfile->getMetadata("MS_ENCRYPTION_KEY")) {
-      ((MainWindow *) parent())->pushUndoStack(new SetMetadataCommand("MS_ENCRYPTION_KEY",
-                                                                      ui->mf_map_config_encryption->text(), this->mapfile));
+    // encryption key (map options)
+    if (ui->mf_map_config_encryption->text() != this->mapfile->getConfigOption("MS_ENCRYPTION_KEY")) {
+      ((MainWindow *) parent())->pushUndoStack(new SetConfigOptionCommand("MS_ENCRYPTION_KEY",
+                                                                          ui->mf_map_config_encryption->text(), this->mapfile));
     }
 
+    // MS_NONSQUARE (map options)
+    QString msNonSquare = this->mapfile->getConfigOption("MS_NONSQUARE").toLower();
     if (ui->mf_map_config_squarepixel_on->isChecked()) {
-      if (this->mapfile->getMetadata("MS_NONSQUARE") != "ON") {
-        ((MainWindow *) parent())->pushUndoStack(new SetMetadataCommand("MS_NONSQUARE", "ON", this->mapfile));
+      if (msNonSquare != "yes") {
+        ((MainWindow *) parent())->pushUndoStack(new SetConfigOptionCommand("MS_NONSQUARE", "yes", this->mapfile));
       }
     } else if (ui->mf_map_config_squarepixel_off->isChecked()) {
-       if (this->mapfile->getMetadata("MS_NONSQUARE") != "OFF") {
-        ((MainWindow *) parent())->pushUndoStack(new SetMetadataCommand("MS_NONSQUARE", "OFF", this->mapfile));
+       if (msNonSquare != "no") {
+        ((MainWindow *) parent())->pushUndoStack(new SetConfigOptionCommand("MS_NONSQUARE", "no", this->mapfile));
       }
     }
 
-    if (ui->mf_map_config_projlib->text() != this->mapfile->getMetadata("PROJ_LIB")) {
-      ((MainWindow *) parent())->pushUndoStack(new SetMetadataCommand("PROJ_LIB",
-                                                                      ui->mf_map_config_projlib->text(), this->mapfile));
+    // PROJ_LIB (map option)
+    if (ui->mf_map_config_projlib->text() != this->mapfile->getConfigOption("PROJ_LIB")) {
+      ((MainWindow *) parent())->pushUndoStack(new SetConfigOptionCommand("PROJ_LIB",
+                                                                          ui->mf_map_config_projlib->text(), this->mapfile));
     }
 
     /** Outputformat tab **/

--- a/mapsettings.h
+++ b/mapsettings.h
@@ -47,6 +47,7 @@
 #include "commands/changemapstatuscommand.h"
 #include "commands/outputformatcommands.h"
 #include "commands/setanglecommand.h"
+#include "commands/setconfigoptioncommand.h"
 #include "commands/setdatapatterncommand.h"
 #include "commands/setdefresolutioncommand.h"
 #include "commands/setimagecolorcommand.h"

--- a/parser/mapfileparser.cpp
+++ b/parser/mapfileparser.cpp
@@ -851,7 +851,9 @@ void MapfileParser::updateOutputFormat(OutputFormat * const of) {
   for (int i = 0; i < this->outputFormats.size(); ++i) {
     if (this->outputFormats[i]->getName() == of->getName()) {
       delete this->outputFormats[i];
-      this->outputFormats[i] = of;
+      // Passed argument lifecycle is managed by the QUndo command
+      // we need to copy it.
+      this->outputFormats[i] = new OutputFormat(* of);
       break;
     }
   }

--- a/parser/mapfileparser.cpp
+++ b/parser/mapfileparser.cpp
@@ -105,6 +105,24 @@ MapfileParser::MapfileParser(const QString & fname) :
   this->mapPath = QString();
   this->outputFormats = QList<OutputFormat *>();
   this->defaultOutputFormat = QString();
+  this->width = -1;
+  this->height = -1;
+  this->mapMaxSize = -1;
+  this->mapUnits  = -1;
+  this->mapImageType = QString();
+  this->mapProjection = QString();
+  this->minx = -1, this->miny = -1, this->maxx = -1, this->maxy = -1;
+  this->debug = false;
+  this->configOptions = QHash<QString,QString>();
+  this->metadatas = QHash<QString,QString>();
+  this->shapePath = QString();
+  this->symbolSet = QString();
+  this->fontSet = QString();
+  this->resolution = -1;
+  this->defResolution = -1;
+  this->angle = -1;
+  this->templatePattern = QString();
+  this->dataPattern = QString();
 
   if (this->map) {
     // name
@@ -140,13 +158,50 @@ MapfileParser::MapfileParser(const QString & fname) :
    // default output format
    this->defaultOutputFormat = QString(this->map->imagetype);
 
+   // width
+   this->width = this->map->width;
+   // height
+   this->height = this->map->height;
+   // map max size
+   this->mapMaxSize = this->map->maxsize;
+   // map units
+   this->mapUnits = this->map->units;
+   // map image type
+   this->mapImageType = this->map->imagetype;
+   // map projection
+   char * tmp = msGetProjectionString(& (this->map->projection));
+   this->mapProjection = tmp;
+   free(tmp);
+   // map extent
+   this->minx = this->map->extent.minx;
+   this->miny = this->map->extent.miny;
+   this->maxx = this->map->extent.maxx;
+   this->maxy = this->map->extent.maxy;
+   // debug
+   this->debug = this->map->debug;
+   // config options
+   this->configOptions = populateMapFromMs(& (this->map->configoptions));
+   // metadatas
+   this->metadatas = populateMapFromMs(& (this->map->web.metadata));
+   // symbolset
+   this->symbolSet = this->map->symbolset.filename;
+   // fontset
+   this->fontSet = this->map->fontset.filename;
+   // map resolution
+   this->resolution = this->map->resolution;
+   // def resolution
+   this->defResolution = this->map->defresolution;
+   // angle
+   this->angle = this->map->gt.rotation_angle;
+   // data pattern
+   this->dataPattern = this->map->datapattern;
   }
 }
 
 /**
  * Related method to create an image representation of the current map
  */
-int MapfileParser::getCurrentMapImageSize() {
+int const & MapfileParser::getCurrentMapImageSize() const {
   return this->currentImageSize;
 }
 
@@ -234,8 +289,6 @@ void MapfileParser::addLayer(QString const & layerName, QString const & dataStr,
   msInsertLayer(this->map, newLayer, -1);
 }
 
-
-
 // Map name
 QString const & MapfileParser::getMapName() const {
   return name;
@@ -264,61 +317,56 @@ void MapfileParser::setMapStatus(const bool & status) {
 }
 
 // Width/Height parameters
-int MapfileParser::getMapWidth() {
-  if (this->map)
-    return this->map->width;
-  return -1;
+int const & MapfileParser::getMapWidth() const {
+  return this->width;
 }
 
-int MapfileParser::getMapHeight() {
-  if (this->map)
-    return this->map->height;
-  return -1;
+int const & MapfileParser::getMapHeight() const {
+  return this->height;
 }
 
 void MapfileParser::setMapSize(const int & width, const int & height) {
    if (this->map) {
-    this->map->width = width;
-    this->map->height = height;
+     this->width = width;
+     this->height = height;
+     this->map->width = width;
+     this->map->height = height;
   }
 }
 
-int MapfileParser::getMapMaxsize() {
-  if (this->map)
-    return this->map->maxsize;
-  return -1;
+int const & MapfileParser::getMapMaxsize() const {
+  return this->mapMaxSize;
 }
 
 void MapfileParser::setMapMaxsize(const int & maxsize) {
   if (this->map) {
+    this->mapMaxSize = maxsize;
     this->map->maxsize = maxsize;
   }
 }
 
 // units parameter
-int MapfileParser::getMapUnits() {
-  if (this->map)
-    return this->map->units;
-  return -1;
+int const & MapfileParser::getMapUnits() const {
+  return this->mapUnits;
 }
 
 void MapfileParser::setMapUnits(const QString & units) {
   if (this->map) {
+    this->mapUnits = this->units.indexOf(units);
     this->map->units = (enum MS_UNITS) this->units.indexOf(units);
   }
 }
 void MapfileParser::setMapUnits(int const & units) {
   if (this->map) {
+    this->mapUnits = units;
     this->map->units = (enum MS_UNITS) units;
   }
 }
 
 
 // imageType parameter
-QString MapfileParser::getMapImageType() {
-  if (this->map)
-    return this->map->imagetype;
-  return QString();
+QString const & MapfileParser::getMapImageType() const {
+  return this->mapImageType;
 }
 
 void MapfileParser::setMapImageType(const QString & imageType) {
@@ -327,54 +375,45 @@ void MapfileParser::setMapImageType(const QString & imageType) {
   if (this->map->imagetype) {
     free(this->map->imagetype);
   }
+  this->mapImageType = imageType;
   this->map->imagetype = (char *) strdup(imageType.toStdString().c_str());
 }
 
 //projection parameters
-QString MapfileParser::getMapProjection() {
-  QString ret = QString();
-  if (this->map) {
-    char * tmp = msGetProjectionString(& (this->map->projection));
-    ret = QString(tmp);
-    free(tmp);
-    return ret;
-  }
-  return QString();
+QString const & MapfileParser::getMapProjection() const {
+  return this->mapProjection;
 }
 
 void MapfileParser::setMapProjection(const QString & projection) {
     if (this->map) {
+      this->mapProjection = projection;
       msLoadProjectionStringEPSG(& (this->map->projection), projection.toStdString().c_str());
     }
 }
 
 // Extent object parameters
-double MapfileParser::getMapExtentMinX() {
-  if (this->map)
-    return this->map->extent.minx;
-  return -1;
+double const & MapfileParser::getMapExtentMinX() const {
+  return this->minx;
 }
 
-double MapfileParser::getMapExtentMinY() {
-  if (this->map)
-    return this->map->extent.miny;
-  return -1;
+double const & MapfileParser::getMapExtentMinY() const {
+  return this->miny;
 }
 
-double MapfileParser::getMapExtentMaxX() {
-  if (this->map)
-    return this->map->extent.maxx;
-  return -1;
+double const & MapfileParser::getMapExtentMaxX() const {
+  return this->maxx;
 }
 
-double MapfileParser::getMapExtentMaxY() {
-  if (this->map)
-    return this->map->extent.maxy;
-  return -1;
+double const & MapfileParser::getMapExtentMaxY() const {
+  return this->maxy;
 }
 
 void MapfileParser::setMapExtent(const double & minx, const double & miny, const double & maxx, const double & maxy) {
   if (this->map) {
+    this->minx = minx;
+    this->miny = miny;
+    this->maxx = maxx;
+    this->maxy = maxy;
     this->map->extent.minx = minx;
     this->map->extent.miny = miny;
     this->map->extent.maxx = maxx;
@@ -382,10 +421,8 @@ void MapfileParser::setMapExtent(const double & minx, const double & miny, const
   }
 }
 
-int MapfileParser::getDebug() {
-    if (this->map)
-        return this->map->debug;
-    return false;
+int const & MapfileParser::getDebug() const {
+  return this->debug;
 }
 
 void MapfileParser::setDebug(const int & debug) {
@@ -436,29 +473,29 @@ void MapfileParser::removeFromMsMap(void *table, const QString &name) {
 /**
  * map configuration options (nested into map->configoptions)
  */
-QHash<QString, QString> MapfileParser::getConfigOptions() {
-  if (! this->map)
-    return QHash<QString, QString>();
-  // TODO: same remark as for metadatas
-  return populateMapFromMs(& (this->map->configoptions));
+QHash<QString, QString> const & MapfileParser::getConfigOptions() const {
+  return this->configOptions;
 }
 
-QString MapfileParser::getConfigOption(const QString &key) {
-  return this->getConfigOptions().value(key, QString());
+QString const MapfileParser::getConfigOption(const QString &key) const {
+  return this->configOptions.value(key);
 }
 
 void MapfileParser::setConfigOption(const QString & name, const QString & value) {
   if (! this->map)
     return;
   // Doing nothing if current config option is already set to the given value
-  if (this->getConfigOptions().value(name) == value)
+  if (this->configOptions.value(name) == value)
     return;
+
+  configOptions[name] = value;
   insertIntoMsMap(& (this->map->configoptions), name, value);
 }
 
 void MapfileParser::removeConfigOption(const QString & name) {
   if (! this->map)
     return;
+  configOptions.remove(name);
   removeFromMsMap(& (this->map->configoptions), name);
 }
 
@@ -466,16 +503,12 @@ void MapfileParser::removeConfigOption(const QString & name) {
  * metadatas (nested into map->web).
  */
 
-QHash<QString, QString> MapfileParser::getMetadatas() {
-  if (! this->map)
-    return QHash<QString, QString>();
-  // TODO: this should be done only once, and saved
-  // into a member variable.
-  return populateMapFromMs(& (this->map->web.metadata));
+QHash<QString, QString> const & MapfileParser::getMetadatas() const {
+  return this->metadatas;
 }
 
-QString MapfileParser::getMetadata(const QString & name) {
-  return this->getMetadatas().value(name);
+QString const MapfileParser::getMetadata(const QString & name) const {
+  return this->metadatas.value(name);
 }
 
 void MapfileParser::setMetadata(const QString & name, const QString & value) {
@@ -483,143 +516,143 @@ void MapfileParser::setMetadata(const QString & name, const QString & value) {
     return;
   if (this->getMetadatas().value(name) == value)
     return;
+  this->metadatas[name] = value;
   insertIntoMsMap(& (this->map->web.metadata), name, value);
 }
 
 void MapfileParser::removeMetadata(const QString & name) {
   if (! this->map)
     return;
+  this->metadatas.remove(name);
   removeFromMsMap(& (this->map->web.metadata), name);
 }
 
 // WFS operations
 
 bool MapfileParser::wfsGetCapabilitiesEnabled() {
-  return (((this->getMetadatas().value("wfs_enable_request").contains("*") ||
-       (this->getMetadatas().value("wfs_enable_request").contains("GetCapabilities")))
-      && (! this->getMetadatas().value("wfs_enable_request").contains("!GetCapabilities")))
+  return (((this->metadatas.value("wfs_enable_request").contains("*") ||
+       (this->metadatas.value("wfs_enable_request").contains("GetCapabilities")))
+      && (! this->metadatas.value("wfs_enable_request").contains("!GetCapabilities")))
     ||
-    ((this->getMetadatas().value("ows_enable_request").contains("*") ||
-       (this->getMetadatas().value("ows_enable_request").contains("GetCapabilities")))
-      && (! this->getMetadatas().value("ows_enable_request").contains("!GetCapabilities"))));
+    ((this->metadatas.value("ows_enable_request").contains("*") ||
+       (this->metadatas.value("ows_enable_request").contains("GetCapabilities")))
+      && (! this->metadatas.value("ows_enable_request").contains("!GetCapabilities"))));
 }
 
 bool MapfileParser::wfsGetFeatureEnabled() {
-  return (((this->getMetadatas().value("wfs_enable_request").contains("*") ||
-       (this->getMetadatas().value("wfs_enable_request").contains("GetFeature")))
-      && (! this->getMetadatas().value("wfs_enable_request").contains("!GetFeature")))
+  return (((this->metadatas.value("wfs_enable_request").contains("*") ||
+       (this->metadatas.value("wfs_enable_request").contains("GetFeature")))
+      && (! this->metadatas.value("wfs_enable_request").contains("!GetFeature")))
     ||
-    ((this->getMetadatas().value("ows_enable_request").contains("*") ||
-       (this->getMetadatas().value("ows_enable_request").contains("GetFeature")))
-      && (! this->getMetadatas().value("ows_enable_request").contains("!GetFeature"))));
+    ((this->metadatas.value("ows_enable_request").contains("*") ||
+       (this->metadatas.value("ows_enable_request").contains("GetFeature")))
+      && (! this->metadatas.value("ows_enable_request").contains("!GetFeature"))));
 }
 
 bool MapfileParser::wfsDescribeFeatureTypeEnabled() {
-  return (((this->getMetadatas().value("wfs_enable_request").contains("*") ||
-       (this->getMetadatas().value("wfs_enable_request").contains("DescribeFeatureType")))
-      && (! this->getMetadatas().value("wfs_enable_request").contains("!DescribeFeatureType")))
+  return (((this->metadatas.value("wfs_enable_request").contains("*") ||
+       (this->metadatas.value("wfs_enable_request").contains("DescribeFeatureType")))
+      && (! this->metadatas.value("wfs_enable_request").contains("!DescribeFeatureType")))
     ||
-    ((this->getMetadatas().value("ows_enable_request").contains("*") ||
-       (this->getMetadatas().value("ows_enable_request").contains("DescribeFeatureType")))
-      && (! this->getMetadatas().value("ows_enable_request").contains("!DescribeFeatureType"))));
+    ((this->metadatas.value("ows_enable_request").contains("*") ||
+       (this->metadatas.value("ows_enable_request").contains("DescribeFeatureType")))
+      && (! this->metadatas.value("ows_enable_request").contains("!DescribeFeatureType"))));
 }
 
 // WMS operations
 
 bool MapfileParser::wmsGetMapEnabled() {
-  return (((this->getMetadatas().value("wms_enable_request").contains("*") ||
-       (this->getMetadatas().value("wms_enable_request").contains("GetMap")))
-      && (! this->getMetadatas().value("wms_enable_request").contains("!GetMap")))
+  return (((this->metadatas.value("wms_enable_request").contains("*") ||
+       (this->metadatas.value("wms_enable_request").contains("GetMap")))
+      && (! this->metadatas.value("wms_enable_request").contains("!GetMap")))
     ||
-    ((this->getMetadatas().value("ows_enable_request").contains("*") ||
-       (this->getMetadatas().value("ows_enable_request").contains("GetMap")))
-      && (! this->getMetadatas().value("ows_enable_request").contains("!GetMap"))));
+    ((this->metadatas.value("ows_enable_request").contains("*") ||
+       (this->metadatas.value("ows_enable_request").contains("GetMap")))
+      && (! this->metadatas.value("ows_enable_request").contains("!GetMap"))));
 }
 
 bool MapfileParser::wmsGetLegendGraphicEnabled() {
-  return (((this->getMetadatas().value("wms_enable_request").contains("*") ||
-       (this->getMetadatas().value("wms_enable_request").contains("GetLegendGraphic")))
-      && (! this->getMetadatas().value("wms_enable_request").contains("!GetLegendGraphic")))
+  return (((this->metadatas.value("wms_enable_request").contains("*") ||
+       (this->metadatas.value("wms_enable_request").contains("GetLegendGraphic")))
+      && (! this->metadatas.value("wms_enable_request").contains("!GetLegendGraphic")))
     ||
-    ((this->getMetadatas().value("ows_enable_request").contains("*") ||
-       (this->getMetadatas().value("ows_enable_request").contains("GetLegendGraphic")))
-      && (! this->getMetadatas().value("ows_enable_request").contains("!GetLegendGraphic"))));
+    ((this->metadatas.value("ows_enable_request").contains("*") ||
+       (this->metadatas.value("ows_enable_request").contains("GetLegendGraphic")))
+      && (! this->metadatas.value("ows_enable_request").contains("!GetLegendGraphic"))));
 }
 
 bool MapfileParser::wmsGetCapabilitiesEnabled() {
-  return (((this->getMetadatas().value("wms_enable_request").contains("*") ||
-       (this->getMetadatas().value("wms_enable_request").contains("GetCapabilities")))
-      && (! this->getMetadatas().value("wms_enable_request").contains("!GetCapabilities")))
+  return (((this->metadatas.value("wms_enable_request").contains("*") ||
+       (this->metadatas.value("wms_enable_request").contains("GetCapabilities")))
+      && (! this->metadatas.value("wms_enable_request").contains("!GetCapabilities")))
     ||
-    ((this->getMetadatas().value("ows_enable_request").contains("*") ||
-       (this->getMetadatas().value("ows_enable_request").contains("GetCapabilities")))
-      && (! this->getMetadatas().value("ows_enable_request").contains("!GetCapabilities"))));
+    ((this->metadatas.value("ows_enable_request").contains("*") ||
+       (this->metadatas.value("ows_enable_request").contains("GetCapabilities")))
+      && (! this->metadatas.value("ows_enable_request").contains("!GetCapabilities"))));
 }
 
 bool MapfileParser::wmsGetFeatureInfoEnabled() {
-  return (((this->getMetadatas().value("wms_enable_request").contains("*") ||
-       (this->getMetadatas().value("wms_enable_request").contains("GetFeatureInfo")))
-      && (! this->getMetadatas().value("wms_enable_request").contains("!GetFeatureInfo")))
+  return (((this->metadatas.value("wms_enable_request").contains("*") ||
+       (this->metadatas.value("wms_enable_request").contains("GetFeatureInfo")))
+      && (! this->metadatas.value("wms_enable_request").contains("!GetFeatureInfo")))
     ||
-    ((this->getMetadatas().value("ows_enable_request").contains("*") ||
-       (this->getMetadatas().value("ows_enable_request").contains("GetFeatureInfo")))
-      && (! this->getMetadatas().value("ows_enable_request").contains("!GetFeatureInfo"))));
+    ((this->metadatas.value("ows_enable_request").contains("*") ||
+       (this->metadatas.value("ows_enable_request").contains("GetFeatureInfo")))
+      && (! this->metadatas.value("ows_enable_request").contains("!GetFeatureInfo"))));
 }
 
 QString MapfileParser::getMetadataWmsTitle() {
-  QString ret = this->getMetadatas().value("wms_title", QString());
+  QString ret = this->metadatas.value("wms_title", QString());
   // Empty, lets try with OWS_TITLE
   if (ret.isEmpty()) {
-    return this->getMetadatas().value("ows_title", QString());
+    return this->metadatas.value("ows_title", QString());
   }
   return ret;
 }
 
 QString MapfileParser::getMetadataWfsTitle() {
-  QString ret = this->getMetadatas().value("wfs_title", QString());
+  QString ret = this->metadatas.value("wfs_title", QString());
   if (ret.isEmpty()) {
-    return this->getMetadatas().value("ows_title", QString());
+    return this->metadatas.value("ows_title", QString());
   }
   return ret;
 }
 
 QString MapfileParser::getMetadataWmsOnlineresource() {
-  QString ret = this->getMetadatas().value("wms_onlineresource", QString());
+  QString ret = this->metadatas.value("wms_onlineresource", QString());
   if (ret.isEmpty()) {
-    return this->getMetadatas().value("ows_onlineresource", QString());
+    return this->metadatas.value("ows_onlineresource", QString());
   }
   return ret;
 }
 
 QString MapfileParser::getMetadataWfsOnlineresource() {
-  QString ret = this->getMetadatas().value("wfs_onlineresource", QString());
+  QString ret = this->metadatas.value("wfs_onlineresource", QString());
   if (ret.isEmpty()) {
-    return this->getMetadatas().value("ows_onlineresource", QString());
+    return this->metadatas.value("ows_onlineresource", QString());
   }
   return ret;
 }
 
 QString MapfileParser::getMetadataWmsSrs() {
-  QString ret = this->getMetadatas().value("wms_srs", QString());
+  QString ret = this->metadatas.value("wms_srs", QString());
   if (ret.isEmpty()) {
-    return this->getMetadatas().value("ows_srs", QString());
+    return this->metadatas.value("ows_srs", QString());
   }
   return ret;
 }
 
 QString MapfileParser::getMetadataWfsSrs() {
-  QString ret = this->getMetadatas().value("wfs_srs", QString());
+  QString ret = this->metadatas.value("wfs_srs", QString());
   if (ret.isEmpty()) {
-    return this->getMetadatas().value("ows_srs", QString());
+    return this->metadatas.value("ows_srs", QString());
   }
   return ret;
 }
 
 
-QString MapfileParser::getShapepath() {
-    if (this->map)
-        return this->map->shapepath;
-    return NULL;
+QString const & MapfileParser::getShapepath() const {
+  return this->shapePath;
 }
 
 void MapfileParser::setShapepath(const QString & shapepath) {
@@ -627,15 +660,13 @@ void MapfileParser::setShapepath(const QString & shapepath) {
         if (this->map->shapepath) {
             free(this->map->shapepath);
         }
+        this->shapePath = shapepath;
         this->map->shapepath = (char *) strdup(shapepath.toStdString().c_str());
     }
 }
 
-QString MapfileParser::getSymbolSet() {
-    if (this->map) {
-        return this->map->symbolset.filename;
-    }
-    return QString();
+QString const & MapfileParser::getSymbolSet() const {
+  return this->symbolSet;
 }
 
 void MapfileParser::setSymbolSet(const QString & symbolset) {
@@ -643,14 +674,13 @@ void MapfileParser::setSymbolSet(const QString & symbolset) {
         if (this->map->symbolset.filename) {
             free(this->map->symbolset.filename);
         }
+        this->symbolSet = symbolset;
         this->map->symbolset.filename = (char *) strdup(symbolset.toStdString().c_str());
     }
 }
 
-QString MapfileParser::getFontSet() {
-    if (this->map)
-        return this->map->fontset.filename;
-    return QString();
+QString const & MapfileParser::getFontSet() const {
+  return this->fontSet;
 }
 
 void MapfileParser::setFontSet(const QString & fontset) {
@@ -658,28 +688,25 @@ void MapfileParser::setFontSet(const QString & fontset) {
         if (this->map->fontset.filename) {
             free(this->map->fontset.filename);
         }
+        this->fontSet = fontset;
         this->map->fontset.filename = (char *) strdup(fontset.toStdString().c_str());
     }
 }
 
 
-double MapfileParser::getResolution() {
-    if (this->map) {
-        return this->map->resolution;
-    }
-    return -1;
+double const & MapfileParser::getResolution() const {
+  return this->resolution;
 }
 
 void MapfileParser::setResolution(const double & resolution) {
-    if (this->map) {
-        this->map->resolution = resolution;
-    }
+  if (this->map) {
+    this->resolution = resolution;
+    this->map->resolution = resolution;
+  }
 }
 
-double MapfileParser::getDefResolution() {
-    if (this->map)
-        return this->map->defresolution;
-    return -1;
+double const & MapfileParser::getDefResolution() const {
+  return this->defResolution;
 }
 
 void MapfileParser::setDefResolution(const double & resolution) {
@@ -688,39 +715,33 @@ void MapfileParser::setDefResolution(const double & resolution) {
     }
 }
 
-float MapfileParser::getAngle() {
-    if (this->map)
-        return this->map->gt.rotation_angle;
-    return -1.0;
+float const & MapfileParser::getAngle() const {
+  return this->angle;
 }
 
 void MapfileParser::setAngle(const float & angle) {
-    if (this->map) {
-        this->map->gt.rotation_angle = angle;
-    }
+  if (this->map) {
+    this->angle = angle;
+    this->map->gt.rotation_angle = angle;
+  }
 }
 
-QString MapfileParser::getTemplatePattern() {
-    if (this->map) {
-        return this->map->templatepattern;
-    }
-    return QString();
+QString const & MapfileParser::getTemplatePattern() const {
+  return  this->templatePattern;
 }
 
 void MapfileParser::setTemplatePattern(const QString & pattern) {
-    if (this->map) {
-        if (this->map->templatepattern) {
-            free(this->map->templatepattern);
-        }
-        this->map->templatepattern = (char *) strdup(pattern.toStdString().c_str());
+  if (this->map) {
+    if (this->map->templatepattern) {
+      free(this->map->templatepattern);
     }
+    this->templatePattern = pattern;
+    this->map->templatepattern = (char *) strdup(pattern.toStdString().c_str());
+  }
 }
 
-QString MapfileParser::getDataPattern() {
-    if (this->map) {
-        return this->map->datapattern;
-    }
-    return QString();
+QString const & MapfileParser::getDataPattern() const {
+  return this->dataPattern;
 }
 
 void MapfileParser::setDataPattern(const QString & pattern) {
@@ -776,6 +797,10 @@ QList<OutputFormat *> const & MapfileParser::getOutputFormats() const {
  * This is the role of the caller to destroy the created object.
  * TODO: scan this->outputFormats instead ?
  * Then remove the delete() from the QUndo command ?
+ *
+ * We have to create a new OF because in case of a delete, the object
+ * no longer exist and the QUndo command still need it (in case of redo
+ * command, to recreate the deleted OF).
  */
 OutputFormat * MapfileParser::getOutputFormat(QString const & name) {
 
@@ -803,7 +828,7 @@ OutputFormat * MapfileParser::getOutputFormat(QString const & name) {
   return item;
 }
 
-void MapfileParser::removeOutputFormat(OutputFormat const * of) {
+void MapfileParser::removeOutputFormat(OutputFormat * const of) {
   if (! this->map)
     return;
 

--- a/parser/mapfileparser.cpp
+++ b/parser/mapfileparser.cpp
@@ -914,7 +914,7 @@ void MapfileParser::addOutputFormat(OutputFormat * const of) {
   if (!this->map)
     return;
 
-  this->outputFormats  << of;
+  this->outputFormats  << new OutputFormat(*of);
   QString fullyQualifiedDriver = of->getDriver();
   if ((of->getDriver() == "GDAL") || (of->getDriver() == "OGR")) {
     fullyQualifiedDriver += "/" + of->getGdalDriver();

--- a/parser/mapfileparser.cpp
+++ b/parser/mapfileparser.cpp
@@ -183,6 +183,8 @@ MapfileParser::MapfileParser(const QString & fname) :
    this->configOptions = populateMapFromMs(& (this->map->configoptions));
    // metadatas
    this->metadatas = populateMapFromMs(& (this->map->web.metadata));
+   // shapepath
+   this->shapePath = this->map->shapepath;
    // symbolset
    this->symbolSet = this->map->symbolset.filename;
    // fontset

--- a/parser/mapfileparser.h
+++ b/parser/mapfileparser.h
@@ -45,20 +45,23 @@ class MapfileParser
   MapfileParser(const QString & filename = "");
   ~MapfileParser();
 
-  QString getMapName();
+  QString const & getMapName() const;
   void setMapName(const QString & name);
-  QString getMapfilePath();
-  QString getMapfileName();
+
+  QString const & getMapfilePath() const;
+  QString const & getMapfileName() const;
 
   void addLayer(QString const &, QString const &, QString const &, int);
 
-  QStringList getLayers(void);
-  QStringList getGdalGdalDrivers(void) { return gdalGdalDrivers; };
-  QStringList getGdalOgrDrivers(void) { return gdalOgrDrivers; };
+  QStringList const & getLayers(void) const;
 
-  QList<OutputFormat *> getOutputFormats(void);
+  QStringList const & getGdalGdalDrivers(void) const { return gdalGdalDrivers; };
+  QStringList const & getGdalOgrDrivers(void)  const { return gdalOgrDrivers;  };
+
+
+  QList<OutputFormat *> const & getOutputFormats(void) const;
   OutputFormat * getOutputFormat(const QString &);
-  QString getDefaultOutputFormat(void) const;
+  QString const & getDefaultOutputFormat(void) const;
 
   void addOutputFormat(OutputFormat const * of);
   void removeOutputFormat(OutputFormat const * of);
@@ -66,7 +69,7 @@ class MapfileParser
 
   void setDefaultOutputFormat(QString const &);
 
-  bool getMapStatus();
+  bool const & getMapStatus() const;
   void setMapStatus(const bool & status);
 
   int  getMapWidth();
@@ -185,9 +188,12 @@ class MapfileParser
   void insertIntoMsMap(void *, const QString &, const QString &);
   void removeFromMsMap(void *, const QString &);
 
-  // This object is necessary, because msGetProjectionString()
-  // will allocate memory that needs to be freed after call.
-  //QString mapProjection;
+  QString name;
+  QStringList layers;
+  bool status;
+  QString mapPath;
+  QList<OutputFormat *> outputFormats;
+  QString defaultOutputFormat;
 
 
 };

--- a/parser/mapfileparser.h
+++ b/parser/mapfileparser.h
@@ -63,9 +63,9 @@ class MapfileParser
   OutputFormat * getOutputFormat(const QString &);
   QString const & getDefaultOutputFormat(void) const;
 
-  void addOutputFormat(OutputFormat const * of);
+  void addOutputFormat(OutputFormat * const of);
   void removeOutputFormat(OutputFormat const * of);
-  void updateOutputFormat(OutputFormat const * of);
+  void updateOutputFormat(OutputFormat * const of);
 
   void setDefaultOutputFormat(QString const &);
 

--- a/parser/mapfileparser.h
+++ b/parser/mapfileparser.h
@@ -64,7 +64,7 @@ class MapfileParser
   QString const & getDefaultOutputFormat(void) const;
 
   void addOutputFormat(OutputFormat * const of);
-  void removeOutputFormat(OutputFormat const * of);
+  void removeOutputFormat(OutputFormat * const of);
   void updateOutputFormat(OutputFormat * const of);
 
   void setDefaultOutputFormat(QString const &);
@@ -72,53 +72,51 @@ class MapfileParser
   bool const & getMapStatus() const;
   void setMapStatus(const bool & status);
 
-  int  getMapWidth();
-  int  getMapHeight();
+  int  const & getMapWidth() const;
+  int  const & getMapHeight() const;
   void setMapSize(const int & width, const int & height);
 
-  int  getMapMaxsize();
+  int  const & getMapMaxsize() const;
   void setMapMaxsize(const int & maxsize);
 
-  int  getMapUnits();
+  int  const & getMapUnits() const;
   void setMapUnits(const QString & units);
   void setMapUnits(int const & units);
 
-  QString getMapImageType();
-  void    setMapImageType(const QString & imageType);
+  QString const & getMapImageType() const;
+  void setMapImageType(const QString & imageType);
 
-  QString getMapProjection();
+  QString const & getMapProjection() const;
   void setMapProjection(const QString & projection);
 
-  double getMapExtentMinX();
-  double getMapExtentMinY();
-  double getMapExtentMaxX();
-  double getMapExtentMaxY();
+  double const & getMapExtentMinX() const;
+  double const & getMapExtentMinY() const;
+  double const & getMapExtentMaxX() const;
+  double const & getMapExtentMaxY() const;
   void setMapExtent(const double & minx, const double & miny, const double & maxx, const double & maxy);
 
   unsigned char * getCurrentMapImage(const int & width = -1, const int & height = -1);
-  int             getCurrentMapImageSize();
+  int const     & getCurrentMapImageSize() const;
 
   bool saveMapfile(const QString & filename);
 
-  int   getDebug();
-  void  setDebug(const int & debug);
+  int const & getDebug() const;
+  void setDebug(const int & debug);
 
+  QString const & getShapepath() const;
+  void setShapepath(const QString & shapepath);
 
+  QString const & getSymbolSet() const;
+  void setSymbolSet(const QString & symbolset);
 
-  QString getShapepath();
-  void    setShapepath(const QString & shapepath);
+  QString const & getFontSet() const;
+  void setFontSet(const QString & fontset);
 
-  QString getSymbolSet();
-  void    setSymbolSet(const QString & symbolset);
+  QString const & getTemplatePattern() const;
+  void setTemplatePattern(const QString & pattern);
 
-  QString getFontSet();
-  void    setFontSet(const QString & fontset);
-
-  QString getTemplatePattern();
-  void    setTemplatePattern(const QString & pattern);
-
-  QString getDataPattern();
-  void    setDataPattern(const QString & pattern);
+  QString const & getDataPattern() const;
+  void setDataPattern(const QString & pattern);
 
   QString getMetadataWmsTitle();
   QString getMetadataWfsTitle();
@@ -135,23 +133,23 @@ class MapfileParser
   bool wmsGetCapabilitiesEnabled();
   bool wmsGetFeatureInfoEnabled();
 
-  QHash<QString, QString> getConfigOptions(void);
-  QString                 getConfigOption(const QString &);
-  void                    setConfigOption(const QString & name, const QString & value);
-  void                    removeConfigOption(const QString & name);
+  QHash<QString, QString> const & getConfigOptions(void) const;
+  QString const getConfigOption(const QString &) const;
+  void setConfigOption(const QString & name, const QString & value);
+  void removeConfigOption(const QString & name);
 
-  QHash<QString, QString> getMetadatas(void);
+  QHash<QString, QString> const & getMetadatas(void) const;
   void setMetadata(const QString & name, const QString & value);
-  QString getMetadata(const QString & name);
+  QString const getMetadata(const QString & name) const;
   void removeMetadata(const QString &);
 
-  double getResolution();
-  void   setResolution(const double & resolution);
+  double const & getResolution() const;
+  void setResolution(const double & resolution);
 
-  double getDefResolution();
-  void   setDefResolution(const double & resolution);
+  double const & getDefResolution() const;
+  void setDefResolution(const double & resolution);
 
-  float getAngle();
+  float const & getAngle() const;
   void setAngle(const float & angle);
 
   QColor getImageColor() const;
@@ -174,7 +172,7 @@ class MapfileParser
   static QStringList IMGdal;
 
  private:
-  // Private plain mapserver object
+  // plain mapserver object
   struct mapObj * map = NULL;
 
   QString filename;
@@ -195,7 +193,30 @@ class MapfileParser
   QList<OutputFormat *> outputFormats;
   QString defaultOutputFormat;
 
+  int width, height;
+  int mapMaxSize;
+  int mapUnits;
 
+  QString mapImageType;
+  QString mapProjection;
+
+  double minx, miny, maxx, maxy;
+
+  int debug;
+
+  QHash<QString,QString> configOptions;
+  QHash<QString,QString> metadatas;
+
+  QString shapePath;
+  QString fontSet;
+  QString symbolSet;
+
+  double resolution, defResolution;
+
+  float angle;
+
+  QString templatePattern;
+  QString dataPattern;
 };
 
 #endif // MAPFILEPARSER_H

--- a/parser/outputformat.cpp
+++ b/parser/outputformat.cpp
@@ -40,6 +40,20 @@ imageMode(imageMode), transparent(transparent), state(state)
   setDriver(driver);
 }
 
+/** copy constructor */
+OutputFormat::OutputFormat(const OutputFormat & of) {
+  name          = of.getName();
+  originalName  = of.getOriginalName();
+  mimeType      = of.getMimeType();
+  extension     = of.getExtension();
+  imageMode     = of.getImageMode();
+  transparent   = of.getTransparent();
+  state         = of.getState();
+  driver        = of.getDriver();
+  gdalDriver    = of.getGdalDriver();
+  formatOptions = QHash<QString,QString>(of.getFormatOptions());
+}
+
 /** Getters */
 QString const & OutputFormat::getName()         const { return name;         }
 QString const & OutputFormat::getOriginalName() const { return originalName; }

--- a/parser/outputformat.cpp
+++ b/parser/outputformat.cpp
@@ -96,11 +96,6 @@ void OutputFormat::setState(enum State const &v)  { state       = v; }
 OutputFormatsModel::OutputFormatsModel(QObject * parent) : QAbstractListModel(parent) {}
 
 OutputFormatsModel::~OutputFormatsModel() {
-  for (int i = 0; i < entries.size(); ++i) {
-    delete entries.at(i);
-  }
-  for (int i = 0 ; i < removedEntries.size() ; ++i)
-    delete removedEntries.at(i);
 }
 
 int OutputFormatsModel::rowCount(const QModelIndex & parent) const {

--- a/parser/outputformat.h
+++ b/parser/outputformat.h
@@ -63,6 +63,7 @@ class OutputFormat {
                 const bool & transparent = 0,
                 const enum State & state = ADDED);
 
+   explicit OutputFormat(const OutputFormat &);
    /** getters */
    QString                 const & getName()          const ;
    QString                 const & getOriginalName()  const ;


### PR DESCRIPTION
- Adding extra member variables to ensure bridging plain mapserver mapObj object and the Qt representation of the mapfile (MapfileParser).
- Fixing mismatch with config options vs map metadatas
- Several fixes around Outputformat lifecycle (create / delete / update ...)

Still far from perfect, but seems stable enough to be merged.
